### PR TITLE
ci: :green_heart: only run ci on `ubuntu-latest`

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -5,12 +5,9 @@ on:
       - master
 jobs:
   build:
-    name: ${{ matrix.kind }} ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+    name: Build and test
+    runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
-    strategy:
-      matrix:
-        os: [macOS-latest, ubuntu-latest, windows-latest]
     env:
       GH_ACTIONS: true
       DENO_BUILD_MODE: release


### PR DESCRIPTION
this is due to the fact that the library does not include OS-specific code, it would be useless to build and test in all platforms.